### PR TITLE
zli-5.1.62-beta

### DIFF
--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -4,8 +4,8 @@ require "os"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/5.1.59/zli-5.1.59.tar.gz"
-  sha256 "ad3aa9fb6cd0d48283b952760b17a3b1af41609fe99e620850ced120b1dd4a27"
+  url "https://github.com/bastionzero/zli/releases/download/5.1.62-beta/zli-5.1.62-beta.tar.gz"
+  sha256 "7a944beed29400ffa347a283e2f2a69619ae8efdfe271e3a386452ebbace70e3"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
@@ -27,6 +27,6 @@ class ZliBeta < Formula
   end
 
   test do
-    system "zli-beta", "configure"
+    system "zli-btage", "configure"
   end
 end


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 5.1.62-beta