### PR TITLE
Remove logic that removed the windows exe

### DIFF
--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -15,7 +15,6 @@ class ZliBeta < Formula
   def install
     system "npm", "install", *Language::Node.local_npm_install_args
     system "npm", "run", "release-prod"
-    rm "./bin/zli-win.exe"
 
     if OS.linux?
       rm "./bin/zli-macos"

--- a/Formula/zli-beta.rb.template
+++ b/Formula/zli-beta.rb.template
@@ -15,7 +15,6 @@ class ZliBeta < Formula
   def install
     system "npm", "install", *Language::Node.local_npm_install_args
     system "npm", "run", "release-prod"
-    rm "./bin/zli-win.exe"
 
     if OS.linux?
       rm "./bin/zli-macos"

--- a/Formula/zli.rb
+++ b/Formula/zli.rb
@@ -15,7 +15,6 @@ class Zli < Formula
   def install
     system "npm", "install", *Language::Node.local_npm_install_args
     system "npm", "run", "release-prod"
-    rm "./bin/zli-win.exe"
 
     if OS.linux?
       rm "./bin/zli-macos"

--- a/Formula/zli.rb.template
+++ b/Formula/zli.rb.template
@@ -15,7 +15,6 @@ class Zli < Formula
   def install
     system "npm", "install", *Language::Node.local_npm_install_args
     system "npm", "run", "release-prod"
-    rm "./bin/zli-win.exe"
 
     if OS.linux?
       rm "./bin/zli-macos"


### PR DESCRIPTION
## Description of the change

We officially do not support windows anymore and no longer build the windows executable. 

This was removed in this commit: https://github.com/bastionzero/zli/commit/8c1e0d95e985b9ad35e1ccdb6d32e12c7c6a7681

## Relevant release note information

Release Notes: Removes windows support logic

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: