### PR TITLE
zli-6.15.14-beta

### DIFF
--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -4,8 +4,8 @@ require "os"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.15.12-beta/zli-6.15.12-beta.tar.gz"
-  sha256 "92aba4479a3e5707c3ba7449a79573bc52ab8b53e768299e959c445bd3c195a2"
+  url "https://github.com/bastionzero/zli/releases/download/6.15.14-beta/zli-6.15.14-beta.tar.gz"
+  sha256 "7b04c67aeb86f55608985befae459598b86b016dd8cbd708d85f68ee0a498a43"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
 

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -26,6 +26,6 @@ class ZliBeta < Formula
   end
 
   test do
-    system "zli-beta", "configure"
+    system "#{bin}/zli-beta", "configure"
   end
 end

--- a/Formula/zli.rb
+++ b/Formula/zli.rb
@@ -26,6 +26,6 @@ class Zli < Formula
   end
 
   test do
-    system "zli", "configure"
+    system "#{bin}/zli", "configure"
   end
 end


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.15.14-beta

Modified the test block of the formula after we started getting sytnax errors in Brew TestBot

See https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md#add-a-test-to-the-formula