### PR TITLE
zli-6.25.3

### DIFF
--- a/Formula/zli.rb
+++ b/Formula/zli.rb
@@ -4,8 +4,8 @@ require "os"
 class Zli < Formula
   desc "BastionZero cli"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.25.2/zli-6.25.2.tar.gz"
-  sha256 "901aa941f47c7379c382702f7abec4951c3d23d5d547b4a16d2cc274aef55848"
+  url "https://github.com/bastionzero/zli/releases/download/6.25.3/zli-6.25.3.tar.gz"
+  sha256 "bb78778940e0f5486b9e444fd91fd3750c6b2acfc446c2234f01649b9ed0f8f8"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
 


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.25.3