### PR TITLE
add HOMEBREW_NO_INSTALL_FROM_API=1 to pr-pull command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,4 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --no-commit --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: export HOMEBREW_NO_INSTALL_FROM_API=1 ; brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST


### PR DESCRIPTION
## Description of the change

Description here (why is it needed, what does it do)....

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: