### PR TITLE
zli-6.28.0-beta-homebrew

### DIFF
--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,20 +5,10 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.27.4-beta/zli-6.27.4-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "c61c9cfcd82cc9f38b42b308b4c111925aa1755adcf709c56bd9f13252f88678"
+  url "https://github.com/bastionzero/zli/releases/download/6.28.0-beta/zli-6.28.0-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
+  sha256 "ff5d646a2327756c078a0094642741a70edecde4144aa702656edb2249fb03b5"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.27.4-beta"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b2bf6057cd71cc7fca61556e525dae98a71ba7893a333061a998540041eeed15"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8b7aba0c92982e43a8da4060701b0f7c3538146eb956d22823d4581bc056bd5e"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a560d6c833fbe4b033b787cc3188da28665210145dab5ce32e67464499ed7737"
-    sha256 cellar: :any_skip_relocation, ventura:        "c039fe0bc17c2d2dcbb801a80ddadf2a8e55a7e5935a2c50f1d51001f7cef8d4"
-    sha256 cellar: :any_skip_relocation, monterey:       "4ceb3935eb95dbdabf63c3f136c2d3e5090ca8ab0daed75af3222b81882e1e2b"
-    sha256 cellar: :any_skip_relocation, big_sur:        "90709b0be4ee2d73f102851c5fe64bb9f8ef6cefab38d1eb0a5c5e654c8ecde0"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@14"


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.28.0-beta