### PR TITLE
Use aliasing for versioning support

### DIFF
--- a/.github/Aliases/zli-beta@6.30.2
+++ b/.github/Aliases/zli-beta@6.30.2
@@ -1,0 +1,1 @@
+../Formula/6.30.2/zli-beta.rb

--- a/Formula/6.30.2/zli-beta.rb
+++ b/Formula/6.30.2/zli-beta.rb
@@ -2,7 +2,7 @@ require "language/node"
 require "os"
 require_relative "../lib/git_hub_private_repository_download_strategy"
 
-class ZliBetaAT6302 < Formula
+class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
   url "https://github.com/bastionzero/zli/releases/download/6.30.2-beta/zli-6.30.2-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy


### PR DESCRIPTION
## Description of the change

Wacky idea 1. We can alias the `zli-beta@version` name to a file that is named and classed like the original so that it finds the bottle correctly.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: