### PR TITLE
zli-6.32.0-beta-homebrew-testing

### DIFF
--- a/Aliases/zli-beta@6.30.2
+++ b/Aliases/zli-beta@6.30.2
@@ -1,0 +1,1 @@
+Archive/6.30.2/zli-beta.rb

--- a/Archive/6.30.2/zli-beta.rb
+++ b/Archive/6.30.2/zli-beta.rb
@@ -1,0 +1,42 @@
+require "language/node"
+require "os"
+require_relative "../../lib/git_hub_private_repository_download_strategy"
+
+class ZliBeta < Formula
+  desc "BastionZero cli - Beta"
+  homepage "https://www.bastionzero.com"
+  url "https://github.com/bastionzero/zli/releases/download/6.32.0-beta/zli-6.32.0-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
+  sha256 "46df7b53042ca6a11a68d5761f97637480c85acfd027be03117df785c4f17493"
+  license "Apache-2.0"
+  head "https://github.com/bastionzero/zli.git", branch: "master"
+
+  bottle do
+    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.32.0-beta"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "665ec5304498c57fa144c153a77b580104cb4c459d830534e3d1171ab9eeb328"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "63fe7841bc28cf4f09bada9d0537fe8280d07230a1e448c30c6c6893127feb55"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bb0b6c2830b124b325eb807330d5bbe12d0823d269f7a07a37121770dba38346"
+    sha256 cellar: :any_skip_relocation, ventura:        "2aebc3662376b8c8af7a2ebd08ffd47808399241fdf5fb499f4037bdc97537ad"
+    sha256 cellar: :any_skip_relocation, monterey:       "e7300d32f4303de0dddbf0b1029c15fe09938a047994d167ab99020892986764"
+    sha256 cellar: :any_skip_relocation, big_sur:        "28381beba37dc84074a511c9e30fedf0e9880d46fdf65d1620a19919d022d2a1"
+  end
+
+  depends_on "go@1.20" => :build
+  depends_on "node@14"
+
+  def install
+    system "npm", "install", *Language::Node.local_npm_install_args
+    system "npm", "run", "release-prod"
+
+    if OS.linux?
+      rm "./bin/zli-macos"
+      bin.install "bin/zli-linux" => "zli-beta"
+    else
+      rm "./bin/zli-linux"
+      bin.install "bin/zli-macos" => "zli-beta"
+    end
+  end
+
+  test do
+    system "#{bin}/zli-beta", "configure"
+  end
+end

--- a/Archive/6.30.2/zli-beta.rb
+++ b/Archive/6.30.2/zli-beta.rb
@@ -5,19 +5,19 @@ require_relative "../../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.32.0-beta/zli-6.32.0-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "46df7b53042ca6a11a68d5761f97637480c85acfd027be03117df785c4f17493"
+  url "https://github.com/bastionzero/zli/releases/download/6.30.2-beta/zli-6.30.2-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
+  sha256 "c8ce07daefa911affe9cc1ce6b93d0031041a3b1da60e5bfe2e039b3f90c6bbb"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
   bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.32.0-beta"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "665ec5304498c57fa144c153a77b580104cb4c459d830534e3d1171ab9eeb328"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "63fe7841bc28cf4f09bada9d0537fe8280d07230a1e448c30c6c6893127feb55"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bb0b6c2830b124b325eb807330d5bbe12d0823d269f7a07a37121770dba38346"
-    sha256 cellar: :any_skip_relocation, ventura:        "2aebc3662376b8c8af7a2ebd08ffd47808399241fdf5fb499f4037bdc97537ad"
-    sha256 cellar: :any_skip_relocation, monterey:       "e7300d32f4303de0dddbf0b1029c15fe09938a047994d167ab99020892986764"
-    sha256 cellar: :any_skip_relocation, big_sur:        "28381beba37dc84074a511c9e30fedf0e9880d46fdf65d1620a19919d022d2a1"
+    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.30.2-beta"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3eef7eb151fe3062b27943507bf76c6b3ccf73ea560556d00f035663fa35227b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "589a17b927d4752be812ac3780237868ff7ddddf9376fe91f823fc6dc2bb0c93"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ca3dea07631b7bd790d27fc06577cca68a8018751998f82fc85fb4a594c8c505"
+    sha256 cellar: :any_skip_relocation, ventura:        "ed1c2e9e467552b93c575b4a9f7ff28e05b8592499d9d8f9b51488cf0eca7b46"
+    sha256 cellar: :any_skip_relocation, monterey:       "113c3b31f19f67c683739c6c50dadcb5633cca1dd39695991e2acd80507017e9"
+    sha256 cellar: :any_skip_relocation, big_sur:        "486a350bffc7cb97643d445411921f1e849c8fae31dd1d60b68a9061f06b0513"
   end
 
   depends_on "go@1.20" => :build

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -6,7 +6,7 @@ class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
   url "https://github.com/bastionzero/zli/releases/download/6.32.0-beta/zli-6.32.0-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "$SHA256"
+  sha256 "46df7b53042ca6a11a68d5761f97637480c85acfd027be03117df785c4f17493"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
 

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -36,3 +36,7 @@ class ZliBeta < Formula
     end
   end
   
+  test do
+    system "#{bin}/zli-beta", "configure"
+  end
+end

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -10,6 +10,16 @@ class ZliBeta < Formula
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
+  bottle do
+    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.32.0-beta"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "665ec5304498c57fa144c153a77b580104cb4c459d830534e3d1171ab9eeb328"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "63fe7841bc28cf4f09bada9d0537fe8280d07230a1e448c30c6c6893127feb55"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bb0b6c2830b124b325eb807330d5bbe12d0823d269f7a07a37121770dba38346"
+    sha256 cellar: :any_skip_relocation, ventura:        "2aebc3662376b8c8af7a2ebd08ffd47808399241fdf5fb499f4037bdc97537ad"
+    sha256 cellar: :any_skip_relocation, monterey:       "e7300d32f4303de0dddbf0b1029c15fe09938a047994d167ab99020892986764"
+    sha256 cellar: :any_skip_relocation, big_sur:        "28381beba37dc84074a511c9e30fedf0e9880d46fdf65d1620a19919d022d2a1"
+  end
+
   depends_on "go@1.20" => :build
   depends_on "node@14"
 
@@ -25,8 +35,4 @@ class ZliBeta < Formula
       bin.install "bin/zli-macos" => "zli-beta"
     end
   end
-
-  test do
-    system "#{bin}/zli-beta", "configure"
-  end
-end
+  

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -6,19 +6,9 @@ class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
   url "https://github.com/bastionzero/zli/releases/download/6.32.0-beta/zli-6.32.0-beta.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "46df7b53042ca6a11a68d5761f97637480c85acfd027be03117df785c4f17493"
+  sha256 "$SHA256"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.32.0-beta"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "665ec5304498c57fa144c153a77b580104cb4c459d830534e3d1171ab9eeb328"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "63fe7841bc28cf4f09bada9d0537fe8280d07230a1e448c30c6c6893127feb55"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bb0b6c2830b124b325eb807330d5bbe12d0823d269f7a07a37121770dba38346"
-    sha256 cellar: :any_skip_relocation, ventura:        "2aebc3662376b8c8af7a2ebd08ffd47808399241fdf5fb499f4037bdc97537ad"
-    sha256 cellar: :any_skip_relocation, monterey:       "e7300d32f4303de0dddbf0b1029c15fe09938a047994d167ab99020892986764"
-    sha256 cellar: :any_skip_relocation, big_sur:        "28381beba37dc84074a511c9e30fedf0e9880d46fdf65d1620a19919d022d2a1"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@14"

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -35,7 +35,7 @@ class ZliBeta < Formula
       bin.install "bin/zli-macos" => "zli-beta"
     end
   end
-  
+
   test do
     system "#{bin}/zli-beta", "configure"
   end


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.32.0-beta