### PR TITLE
zli-6.35.1-homebrew

### DIFF
--- a/Formula/zli.rb
+++ b/Formula/zli.rb
@@ -5,19 +5,11 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class Zli < Formula
   desc "BastionZero cli"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.34.10/zli-6.34.10.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.35.1/zli-6.35.1.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "27533fa6c4cb7f80604c12964d54d8246b95319a4753415d5b3a4a643d77a074"
+  sha256 "9aba69b45f17fc99d3ef6824be685991f485c9249804072ae0c3f99514dbe10f"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-6.34.10"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "06cfb9f66d2b14832edc2fc0dd39086a0bb3f893daa409b018440a0f8540bc92"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "bb3a43a4e354271587ad29352bf1ac78388703ec158ac8016baea44395942c7b"
-    sha256 cellar: :any_skip_relocation, ventura:        "9420b12c0797783e738449d1630b909fec180fcf70c75046bd88cba49c49dd50"
-    sha256 cellar: :any_skip_relocation, monterey:       "6d6b171e58609f54da49c75d72294da24694ee64c5bc39df77ae94003088f7f3"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@14"


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.35.1