### PR TITLE
zli-6.35.3-beta-homebrew

### DIFF
--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,19 +5,11 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.35.2-beta/zli-6.35.2-beta.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.35.3-beta/zli-6.35.3-beta.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "b6b673eb69d4068a042c6c9323d1f7988f24dbfc1d0e9a209bf2e4adb0275222"
+  sha256 "9895d37c751bc2d25e985e487ee17715e02f975445359eda6f7216d6ffda2312"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.35.2-beta"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8b9a99d62285190c90b90062520932edf4d3a74588f1d4cc821bf765174f595a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1011982287b29241a4e12ef5af1b8c3e716a698302a9907bfb62ef595e9c3473"
-    sha256 cellar: :any_skip_relocation, ventura:        "4a35c6f3b099138686957e2f2ba258c14d7e14c5a765acb6bd36b2a191f41800"
-    sha256 cellar: :any_skip_relocation, monterey:       "dfcade3a5be7b0f214e273a3670fa4107046763db10f94e25a1e6b34958bab35"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@14"


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.35.3-beta