### PR TITLE
Lock upload-artifact action to previous commit

### DIFF
--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@eba2a242da008728ae72aa629890215a9957fd8a
         with:
           name: bottles
           path: '*.bottle.*'


### PR DESCRIPTION
## Description of the change

upload-artifact seems to be uploading our bottles in blobs instead of as unique items. I think this is causing an issue when we're trying to use the resulting uploads to create a release.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: