### PR TITLE
lock upload-artifact to v3

### DIFF
--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@500e175644c3058b7df0585ddad255d828c91fc5
+        uses: actions/upload-artifact@v3
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@500e175644c3058b7df0585ddad255d828c91fc5
+        uses: actions/upload-artifact@v3
         with:
           name: bottles
           path: '*.bottle.*'


### PR DESCRIPTION
## Description of the change

There seems to be new behavior that's tripping people up in upload-artifact v4. v3 should still work. So, instead of locking to a commit, we'll lock to the version

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: