### PR TITLE
Remove macos-11 support

### DIFF
--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-11-arm, macos-12-arm, macos-13-arm]
+        os: [macos-12-arm, macos-13-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Rosetta for any x86 arch operations

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ BastionZero offers the zli in pre-built binaries for the following matrix.
 | ------------------ | ------------------ | -------------------- |
 | MacOS 13 Ventura   | :white_check_mark: | :white_check_mark:   |
 | MacOS 12 Monterey  | :white_check_mark: | :white_check_mark:   |
-| MacOS 11 Big Sur   | :white_check_mark: | :white_check_mark:   |
 
 ## Downgrading
 BastionZero cannot guarantee compatability when downgrading.


### PR DESCRIPTION
## Description of the change

We no longer support MacOS 11 because brew doesn't. So, I remove it from our build scripts and official support matrix

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: