### PR TITLE
zli-6.36.2-beta-homebrew

### DIFF
--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,17 +5,11 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.36.1-beta/zli-6.36.1-beta.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.36.2-beta/zli-6.36.2-beta.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "30a7687e036b4be680307593341e0b87be0df2f5b70ec13def0f35de9ffd03bb"
+  sha256 "35993e30f92f280d55a3739247ef71a56fb47988ef19c0eb57d3d02f8937c4c9"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.36.1-beta"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "79e935d38006aeb17b4770f663ba04a489bcd359ef90914df61318e3e274615c"
-    sha256 cellar: :any_skip_relocation, ventura:       "177dd798920c8aac76efd8c9cf56146dad49041653642062fe5745d573e0ab7c"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@14"


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.36.2-beta