### PR TITLE
zli-6.36.3-homebrew

### DIFF
--- a/Formula/zli.rb
+++ b/Formula/zli.rb
@@ -5,19 +5,11 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class Zli < Formula
   desc "BastionZero cli"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.36.2/zli-6.36.2.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.36.3/zli-6.36.3.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "b77c5383b2f86ed2aecacabaec842e2cba775740e121b5022161fa3850de30b0"
+  sha256 "0668d9de8e78bb2dfe78fcd5f2b2104865a621aa76a41a846bcd0020a8d631c8"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-6.36.2"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ae3533be7ba1cc411cd9b8f17a697052b08c53e3e1a3b254d4fe4e75f69a0988"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "044ae054e2b0a0238a5dac350c6141c89caedf31c7c54883146aaebbaf708cf8"
-    sha256 cellar: :any_skip_relocation, ventura:        "8a4ff55706ec2ba97f920ca9a20ef10b894b2f1a530af921c80cd2a59480c913"
-    sha256 cellar: :any_skip_relocation, monterey:       "9a1ad119b2262a014deb367301a688a54971ef7119e4647d53b656c8b2cbde35"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@14"


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.36.3