### PR TITLE
Update node dependency to v20

### DIFF
--- a/Formula/zli-beta.rb.template
+++ b/Formula/zli-beta.rb.template
@@ -12,7 +12,7 @@ class ZliBeta < Formula
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
   depends_on "go@1.20" => :build
-  depends_on "node@14"
+  depends_on "node@20"
 
   def install
     system "npm", "install", *Language::Node.local_npm_install_args

--- a/Formula/zli.rb.template
+++ b/Formula/zli.rb.template
@@ -12,7 +12,7 @@ class Zli < Formula
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
   depends_on "go@1.20" => :build
-  depends_on "node@14"
+  depends_on "node@20"
 
   def install
     system "npm", "install", *Language::Node.local_npm_install_args


### PR DESCRIPTION
## Description of the change

Brew testbots no longer support building with node v14 as its reached EOL.

```
Error: node@14 has been disabled because it is not supported upstream!
``` 

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-2969
## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: