### PR TITLE
Make node a build-time only dependency

### DIFF
--- a/Formula/zli-beta.rb.template
+++ b/Formula/zli-beta.rb.template
@@ -12,7 +12,7 @@ class ZliBeta < Formula
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
   depends_on "go@1.20" => :build
-  depends_on "node@20"
+  depends_on "node@20" => :build
 
   def install
     system "npm", "install", *Language::Node.local_npm_install_args

--- a/Formula/zli.rb.template
+++ b/Formula/zli.rb.template
@@ -12,7 +12,7 @@ class Zli < Formula
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
   depends_on "go@1.20" => :build
-  depends_on "node@20"
+  depends_on "node@20" => :build
 
   def install
     system "npm", "install", *Language::Node.local_npm_install_args


### PR DESCRIPTION
## Description of the change

Zli build process uses pkg to bundle the zli into a single executable with node runtime included and therefore we only need node during build/bottling

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: