### PR TITLE
zli-6.36.12-beta-homebrew

### DIFF
--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-12-arm, macos-13-arm]
+        os: [macos-12-arm, macos-13-arm, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Rosetta for any x86 arch operations

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,22 +5,14 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.36.6-beta/zli-6.36.6-beta.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.36.12-beta/zli-6.36.12-beta.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "efa200f8db0a05fb0940e3f22c2742028a800c3a1c3cf256cbe0f8405f3b7023"
+  sha256 "af51d48727150525ba6ee26406f49f99d914450f60f33e015bdb07975c4d5abd"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
 
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.36.6-beta"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "17750e77dd5e005c795e506b5c898731c3e6865de5ed798e38dc5e759ea460f2"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "0b200df6b6470aa1489f3cad6a538ccac8126a0ec2d2c0bfa3620ed542409b1b"
-    sha256 cellar: :any_skip_relocation, ventura:        "38974c2bd45545f4b6a57f2d0a214b237edcb279f1ed8252c6fde1d409204636"
-    sha256 cellar: :any_skip_relocation, monterey:       "e9969093d65e5942274a611aa12da94c37352c5058d276c1ea3c687e20b67e6b"
-  end
-
   depends_on "go@1.20" => :build
-  depends_on "node@20"
+  depends_on "node@20" => :build
 
   def install
     system "npm", "install", *Language::Node.local_npm_install_args


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.36.12-beta