### PR TITLE
zli-6.36.20-beta-homebrew

### DIFF
--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-12-arm, macos-13-xlarge, macos-14]
+        os: [macos-13-xlarge, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Rosetta for any x86 arch operations

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,20 +5,11 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.36.19-beta/zli-6.36.19-beta.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.36.20-beta/zli-6.36.20-beta.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "f5ac689fb9d79f9fabcb169c028a160b10da174de27acfc602c2c234b86d16c2"
+  sha256 "abefb4ce3e2f5be7655da272a49b3cf995c39dae31f78acc3dc0e6176bf79643"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.36.19-beta"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "677d2d67dddd46576a7eaded3a88a43869dae22b4e64076cbaf77ab5ea0297a1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f713f792ccbdb151f1630f2806e33e705b4cacf2171bea72c17beb189779facf"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f973d6f324097c888484640c036eae4e203769e23d6670f2512ebc6e63d9527e"
-    sha256 cellar: :any_skip_relocation, ventura:        "ea8499c8c430701119257968543a2d91d0dd8552f0fd0d96e302a43e9bd0227e"
-    sha256 cellar: :any_skip_relocation, monterey:       "f9d8e920993177b9c16cba11e55b9f4a5cccaa4be43c55de6135929202b59be6"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@20" => :build


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.36.20-beta