### PR TITLE
zli-6.36.21-beta-homebrew

### DIFF
--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,18 +5,11 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.36.20-beta/zli-6.36.20-beta.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.36.21-beta/zli-6.36.21-beta.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "abefb4ce3e2f5be7655da272a49b3cf995c39dae31f78acc3dc0e6176bf79643"
+  sha256 "efcbd94c7a960aab45ee471a76a753f4bcab86bffa96e3b7079a409ff8f9ce5e"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.36.20-beta"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "47458f2f7678524580500b9e4d9d2410f0a35b68b7c035748115dad38978328a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "1d3e6f51a63e558c333526e0eb5faf75848e43b7957d05893cb52d598fae1f10"
-    sha256 cellar: :any_skip_relocation, ventura:       "f3a612b337c599534d02b39d16a748ca1fddd5496218efca5b52a27acc229c3d"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@20" => :build


### PR DESCRIPTION
Auto generated PR via bzero-deploy for Zli version: 6.36.21-beta