### PR TITLE
Update Action packages and add runner for macos 15

### DIFF
--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -58,9 +58,10 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.ROLE_ACCOUNT_GH_ACCESS_TOKEN }}
 
+      # ref: https://github.com/Homebrew/brew/blob/cf635bc28a02d696a16df58ec77ea99524d20d7e/Library/Homebrew/dev-cmd/tap-new.rb
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -52,7 +52,7 @@ jobs:
       # rejected in homebrew audit steps since these urls will return 404 not
       # found unless using a github PAT with access to the repo
       - run: arch -arm64 brew test-bot --only-formulae --skip-online-checks
-        # This is a temporary fix since our zli bulids x86 AND arm which results in a useless error
+        # This is a temporary fix since our zli builds x86 AND arm which results in a useless error
         continue-on-error: true
         if: github.event_name == 'pull_request'
         env:
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-13-xlarge, macos-14]
+        os: [macos-13-xlarge, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Rosetta for any x86 arch operations

--- a/.github/workflows/tests-arm.yml
+++ b/.github/workflows/tests-arm.yml
@@ -65,3 +65,4 @@ jobs:
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'
+          if-no-files-found: error

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,10 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.ROLE_ACCOUNT_GH_ACCESS_TOKEN }}
 
+      # ref: https://github.com/Homebrew/brew/blob/cf635bc28a02d696a16df58ec77ea99524d20d7e/Library/Homebrew/dev-cmd/tap-new.rb
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'
+          if-no-files-found: error

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,18 +5,11 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.36.20-beta/zli-6.36.20-beta.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.36.21-beta/zli-6.36.21-beta.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "abefb4ce3e2f5be7655da272a49b3cf995c39dae31f78acc3dc0e6176bf79643"
+  sha256 "efcbd94c7a960aab45ee471a76a753f4bcab86bffa96e3b7079a409ff8f9ce5e"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.36.20-beta"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "47458f2f7678524580500b9e4d9d2410f0a35b68b7c035748115dad38978328a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "1d3e6f51a63e558c333526e0eb5faf75848e43b7957d05893cb52d598fae1f10"
-    sha256 cellar: :any_skip_relocation, ventura:       "f3a612b337c599534d02b39d16a748ca1fddd5496218efca5b52a27acc229c3d"
-  end
 
   depends_on "go@1.20" => :build
   depends_on "node@20" => :build

--- a/Formula/zli-beta.rb
+++ b/Formula/zli-beta.rb
@@ -5,11 +5,18 @@ require_relative "../lib/git_hub_private_repository_download_strategy"
 class ZliBeta < Formula
   desc "BastionZero cli - Beta"
   homepage "https://www.bastionzero.com"
-  url "https://github.com/bastionzero/zli/releases/download/6.36.21-beta/zli-6.36.21-beta.tar.gz",
+  url "https://github.com/bastionzero/zli/releases/download/6.36.20-beta/zli-6.36.20-beta.tar.gz",
     using: GitHubPrivateRepositoryReleaseDownloadStrategy
-  sha256 "efcbd94c7a960aab45ee471a76a753f4bcab86bffa96e3b7079a409ff8f9ce5e"
+  sha256 "abefb4ce3e2f5be7655da272a49b3cf995c39dae31f78acc3dc0e6176bf79643"
   license "Apache-2.0"
   head "https://github.com/bastionzero/zli.git", branch: "master"
+
+  bottle do
+    root_url "https://github.com/bastionzero/homebrew-tap/releases/download/zli-beta-6.36.20-beta"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "47458f2f7678524580500b9e4d9d2410f0a35b68b7c035748115dad38978328a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1d3e6f51a63e558c333526e0eb5faf75848e43b7957d05893cb52d598fae1f10"
+    sha256 cellar: :any_skip_relocation, ventura:       "f3a612b337c599534d02b39d16a748ca1fddd5496218efca5b52a27acc229c3d"
+  end
 
   depends_on "go@1.20" => :build
   depends_on "node@20" => :build

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ BastionZero offers the zli in pre-built binaries for the following matrix.
 
 | OS                 | x86                | arm64                |
 | ------------------ | ------------------ | -------------------- |
+| MacOS 15 Sequoia   |                    | :white_check_mark:   |
+| MacOS 14 Sonoma    |                    | :white_check_mark:   |
 | MacOS 13 Ventura   | :white_check_mark: | :white_check_mark:   |
-| MacOS 12 Monterey  | :white_check_mark: | :white_check_mark:   |
 
 ## Downgrading
 BastionZero cannot guarantee compatability when downgrading.


### PR DESCRIPTION
## Description of the change

Builds are throwing these errors:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v1`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down. This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

We need to update our action packages to more recent versions.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: